### PR TITLE
.gitignoreの更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+# Ignore dump.rdb
+dump.rdb


### PR DESCRIPTION
redisによって生成されるdumpファイルを無視させるため。